### PR TITLE
Fix scenario map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "click>=8.0",
     "dask>=2025.9.1",
     "h5py>=3.14.0",
     "netcdf4>=1.7.2",

--- a/src/deconto21_ais/cli.py
+++ b/src/deconto21_ais/cli.py
@@ -34,6 +34,7 @@ logging.basicConfig(level=logging.INFO)
     type=str,
     help="NetCDF4/HDF5 file containing surface temperature data",
     envvar="DP21_CLIMATE_DATA_FILE",
+    default="",
 )
 @click.option(
     "--input-eais-rcp26-file",

--- a/src/deconto21_ais/deconto21_ais_preprocess.py
+++ b/src/deconto21_ais/deconto21_ais_preprocess.py
@@ -18,8 +18,8 @@ of this module within the same workflow.
 def dp21_preprocess_icesheet(
     scenario, baseyear, pipeline_id, climate_data_file, input_paths_dict
 ):
-    # If a climate data file is passed
-    if climate_data_file is not None:
+    # keeping f1 approach.
+    if len(climate_data_file) > 0:
         scens = ["rcp26", "rcp45", "rcp85"]
         years, eais_samps, wais_samps = ReadScenarioFile(
             scenario=scens[0], baseyear=baseyear, paths_dict=input_paths_dict
@@ -36,7 +36,6 @@ def dp21_preprocess_icesheet(
         years, eais_samps, wais_samps = ReadScenarioFile(
             scenario, baseyear, input_paths_dict
         )
-
     output = {
         "years": years,
         "eais_samps": eais_samps,
@@ -44,6 +43,7 @@ def dp21_preprocess_icesheet(
         "scenario": scenario,
         "baseyear": baseyear,
     }
+
     return output
 
 

--- a/src/deconto21_ais/deconto21_ais_project.py
+++ b/src/deconto21_ais/deconto21_ais_project.py
@@ -301,13 +301,11 @@ def GetSATData(
 ):
     # Open the file
     df_ssp = h5py.File(fname, "r")
-
     # Extract the surface temperature for this scenario
     if scenario not in df_ssp.keys():
         raise ValueError("Scenario {} not found in {}".format(scenario, fname))
     ssp_folder = df_ssp.get(scenario)
     sat_ssp = ssp_folder.get("surface_temperature")
-
     # Get the number of ensemble members from the data
     _, nens = sat_ssp.shape
 


### PR DESCRIPTION
This fixes a bug that arose when testing with `scenario = "ssp119"` (ie. not in the scenario dict in preprocess script).

If this scenario value was set and `climate-data-file=None`, the if statement in the preprocess script would evaluate to `None is not None = False`, so then would raise keyerror in `scen_dict`. 

This fix should allow scenarios not in `scen_dict` (if climate data file is passed) and default to `scen_dict` if a climate data file isn't provided 